### PR TITLE
:sparkles: fix: 修复特殊情况下滚动失效

### DIFF
--- a/src/ProChat/components/ScrollAnchor/index.tsx
+++ b/src/ProChat/components/ScrollAnchor/index.tsx
@@ -2,18 +2,23 @@ import { memo, useEffect } from 'react';
 import { useInView } from 'react-intersection-observer';
 
 import { useStore } from '@/ProChat/store';
+import { chatSelectors } from '../../store/selectors';
 
 import { useAtBottom } from './useAtBottom';
 
 const ChatScrollAnchor = memo(() => {
   const trackVisibility = useStore((s) => !!s.chatLoadingId);
+  const str = useStore(chatSelectors.currentChats);
 
-  const isAtBottom = useAtBottom();
   const { ref, entry, inView } = useInView({
     delay: 100,
     rootMargin: '0px 0px -150px 0px',
     trackVisibility,
   });
+
+  // 如果是移动端，可能200太多了，认为超过 1/3 即可，PC默认200
+  const ScrollOffset = window.innerHeight / 3 > 200 ? 200 : window.innerHeight / 4;
+  const isAtBottom = useAtBottom(ScrollOffset);
 
   useEffect(() => {
     if (isAtBottom && trackVisibility && !inView) {
@@ -21,7 +26,7 @@ const ChatScrollAnchor = memo(() => {
         block: 'start',
       });
     }
-  }, [inView, entry, isAtBottom, trackVisibility]);
+  }, [inView, entry, isAtBottom, trackVisibility, str]);
 
   return <div ref={ref} style={{ height: 1, width: '100%' }} />;
 });

--- a/src/ProChat/store/selectors/chat.ts
+++ b/src/ProChat/store/selectors/chat.ts
@@ -99,3 +99,8 @@ export const currentChatsWithHistoryConfig = (s: ChatStore): ChatMessage[] => {
 
   return getSlicedMessagesWithConfig(chats, s.config);
 };
+
+export const chatsMessageString = (s: ChatStore): string => {
+  const chats = currentChatsWithHistoryConfig(s);
+  return chats.map((m) => m.content).join('');
+};

--- a/src/ProChat/store/selectors/index.ts
+++ b/src/ProChat/store/selectors/index.ts
@@ -1,6 +1,12 @@
-import { currentChats, currentChatsWithGuideMessage, currentChatsWithHistoryConfig } from './chat';
+import {
+  chatsMessageString,
+  currentChats,
+  currentChatsWithGuideMessage,
+  currentChatsWithHistoryConfig,
+} from './chat';
 
 export const chatSelectors = {
+  chatsMessageString,
   currentChats,
   currentChatsWithGuideMessage,
   currentChatsWithHistoryConfig,


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- \[ ] ✨ feat
- \[x] 🐛 fix
- \[ ] 💄 style
- \[ ] 🔨 chore
- \[ ] 📝 docs

#### 🔀 变更说明 | Description of Change

比较特殊的场景，在 Steam 流式场景下，个人感觉是一次渲染的东西有点多，直接跳过了 useAtBottom 的判定从而不导致自动滚动了。
放开些严格的判定，1/3 屏幕（移动端），200 （PC）这样子的偏移感觉比较合理

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->
