### PR TITLE
:bug: fix: TextDecoder多字节字符断开问题

### DIFF
--- a/src/ProChat/utils/fetch.ts
+++ b/src/ProChat/utils/fetch.ts
@@ -47,7 +47,7 @@ export const fetchSSE = async (fetchFn: () => Promise<Response>, options: FetchS
   while (!done) {
     const { value, done: doneReading } = await reader.read();
     done = doneReading;
-    const chunkValue = decoder.decode(value);
+    const chunkValue = decoder.decode(value, { stream: !doneReading });
 
     options.onMessageHandle?.(chunkValue, returnRes);
   }


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- \[ ] ✨ feat
- \[x] 🐛 fix
- \[ ] 💄 style
- \[ ] 🔨 chore
- \[ ] 📝 docs

#### 🔀 变更说明 | Description of Change

TextDecoder在将Uint8Array转为字符串的过程中，由于read()方法每次获取的是字节，当数据流中存在中文等多字节字符时，会出现将一个字符分成两次读取的情况，这时候decode会将不完全的字节尝试转字符串，会出现乱码。

<img width="912" alt="image" src="https://github.com/ant-design/pro-chat/assets/16523012/e2b8309c-a947-4938-9c5d-76b008724a2e">

---

参考[TextDecoder API文档示例](https://encoding.spec.whatwg.org/#example-end-of-stream)，如下，可以传递`stream: true`参数让decode在解码时关联整条流进行解码。

```js
var string = "", decoder = new TextDecoder(encoding), buffer;
while(buffer = next_chunk()) {
  string += decoder.decode(buffer, {stream:true});
}
string += decoder.decode(); // end-of-queue
```

并且在最后一个chunk将stream参数设为false，结束流模式，处理最后的数据。修改后代码像这样：

```
while (!done) {
  const { value, done: doneReading } = await reader.read();
  done = doneReading;
  const chunkValue = decoder.decode(value, { stream: !doneReading });

  options.onMessageHandle?.(chunkValue, returnRes);
}
```

#### 📝 补充信息 | Additional Information

