### PR TITLE
fix: chrome extension csp error

### DIFF
--- a/src/ProChat/store/action.ts
+++ b/src/ProChat/store/action.ts
@@ -142,7 +142,6 @@ export const chatAction: StateCreator<ChatStore, [['zustand/devtools', never]], 
       t('generateMessage(start)', { assistantId, messages }) as string,
     );
 
-    const compiler = template(config.inputTemplate, { interpolate: /{{([\S\s]+?)}}/g });
 
     // ========================== //
     //   对 messages 做统一预处理    //
@@ -152,20 +151,24 @@ export const chatAction: StateCreator<ChatStore, [['zustand/devtools', never]], 
     const slicedMessages = getSlicedMessagesWithConfig(messages, config);
 
     // 2. 替换 inputMessage 模板
+    const compilerMessages =(slicedMessages:ChatMessage[])=>{
+    const compiler = template(config.inputTemplate, { interpolate: /{{([\S\s]+?)}}/g });
+      return slicedMessages.map((m) => {
+        if (m.role === 'user') {
+          try {
+            return { ...m, content: compiler({ text: m.content }) };
+          } catch (error) {
+            console.error(error);
+
+            return m;
+          }
+        }
+        return m;
+      });
+    }
     const postMessages = !config.inputTemplate
       ? slicedMessages
-      : slicedMessages.map((m) => {
-          if (m.role === 'user') {
-            try {
-              return { ...m, content: compiler({ text: m.content }) };
-            } catch (error) {
-              console.error(error);
-
-              return m;
-            }
-          }
-          return m;
-        });
+      : compilerMessages(slicedMessages);
 
     // 3. 添加 systemRole
     if (config.systemRole) {


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- \[ ] ✨ feat
- \[x] 🐛 fix
- \[ ] 💄 style
- \[ ] 🔨 chore
- \[ ] 📝 docs

#### 🔀 变更说明 | Description of Change

After integrating the SidePanel environment into our browser plugin, we encountered a Content Security Policy (CSP) violation triggered by sending messages. Upon investigation, it was found that the issue stemmed from the use of the lodash template method. This problem occurred regardless of whether the inputTemplate was used or not, preventing message sending.

To resolve this, we modified the implementation to only use the template method when inputTemplate is utilized, which successfully fixed the error.
* https://developer.chrome.com/docs/extensions/reference/manifest/content-security-policy
* https://lodash.com/docs/4.17.15#template

For a more comprehensive solution to this issue in the future, an Ahead-of-Time (AOT) compilation approach is required. Fortunately, the official lodash documentation provides a solution to this problem, which can be found here: https://github.com/lodash/lodash/issues/832.

#### 📝 补充信息 | Additional Information

![image](https://github.com/ant-design/pro-chat/assets/15225835/c6bfb1fa-5a13-4db4-a04a-f953dfea71bf)

