### PR TITLE
messageExtra prefixClass类名缺失

### DIFF
--- a/src/ChatItem/components/MessageContent.tsx
+++ b/src/ChatItem/components/MessageContent.tsx
@@ -1,7 +1,8 @@
 import { useResponsive } from 'antd-style';
-import { memo, type ReactNode } from 'react';
+import { memo, useContext, type ReactNode } from 'react';
 import { Flexbox } from 'react-layout-kit';
 
+import { ConfigProvider } from 'antd';
 import { ChatItemProps } from '@/ChatItem';
 import EditableMessage from '@/EditableMessage';
 
@@ -40,6 +41,9 @@ const MessageContent = memo<MessageContentProps>(
     const { cx, styles } = useStyles({ editing, placement, primary, type });
     const { mobile } = useResponsive();
 
+    const { getPrefixCls } = useContext(ConfigProvider.ConfigContext);
+    const prefixClass = getPrefixCls('pro-chat');
+
     const content = (
       <EditableMessage
         classNames={{ input: styles.editingInput }}
@@ -62,7 +66,7 @@ const MessageContent = memo<MessageContentProps>(
       >
         {messageContent}
         {messageExtra && !editing ? (
-          <div className={styles.messageExtra}>{messageExtra}</div>
+          <div className={`${cx(styles.messageExtra, `${prefixClass}-message-extra`)}`}>{messageExtra}</div>
         ) : null}
       </Flexbox>
     );

--- a/src/ChatItem/index.tsx
+++ b/src/ChatItem/index.tsx
@@ -151,7 +151,7 @@ const ChatItem = memo<ChatItemProps>((props) => {
         {titleDom}
         <Flexbox
           align={placement === 'left' ? 'flex-start' : 'flex-end'}
-          className={styles.messageContent}
+          className={cx(styles.messageContent, `${prefixClass}-message-content`)}
           direction={
             type === 'block'
               ? placement === 'left'

--- a/src/ChatItem/style.ts
+++ b/src/ChatItem/style.ts
@@ -172,7 +172,7 @@ export const useStyles = createStyles(
           }
         `,
       ),
-      messageExtra: cx('message-extra'),
+      messageExtra: css``,
       name: css`
         position: ${showTitle ? 'relative' : 'absolute'};
         top: ${showTitle ? 'unset' : '-16px'};


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- \[ ] ✨ feat
- \[x] 🐛 fix messageExtra类名不带有prefixClass
- \[ ] 💄 style
- \[ ] 🔨 chore
- \[ ] 📝 docs

#### 🔀 变更说明 | Description of Change

给messageExtra添加prefixClass，messageContent添加一个类名
<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information
无
<!-- Add any other context about the Pull Request here. -->
