### PR TITLE
✨ feat: 暴露Input.TextArea的ref到inputAreaProps中

### DIFF
--- a/src/ProChat/components/InputArea/AutoCompleteTextArea.tsx
+++ b/src/ProChat/components/InputArea/AutoCompleteTextArea.tsx
@@ -1,16 +1,18 @@
 ﻿import { AutoComplete, AutoCompleteProps, Input } from 'antd';
 import { TextAreaProps } from 'antd/es/input';
+import { type TextAreaRef } from 'antd/es/input/TextArea';
 import { useState } from 'react';
 import { useStore } from '../../store';
 
 type AutoCompleteTextAreaProps = TextAreaProps & {
   autoCompleteProps?: AutoCompleteProps;
+  reference?: React.Ref<TextAreaRef>;
 };
 
 export const AutoCompleteTextArea: React.FC<AutoCompleteTextAreaProps> = (props) => {
   const [autocompleteRequest] = useStore((s) => [s.autocompleteRequest]);
 
-  const { disabled, autoCompleteProps = {}, ...rest } = props;
+  const { disabled, reference, autoCompleteProps = {}, ...rest } = props;
 
   const [options, setOptions] = useState<{ value: string; label: string }[]>([]);
   const [open, setOpen] = useState(false);
@@ -40,6 +42,7 @@ export const AutoCompleteTextArea: React.FC<AutoCompleteTextAreaProps> = (props)
       <Input.TextArea
         size="large"
         {...rest}
+        ref={reference}
         disabled={disabled}
         className={`${props.className}-textarea`}
         onFocus={(e) => {

--- a/src/ProChat/store/initialState.ts
+++ b/src/ProChat/store/initialState.ts
@@ -4,6 +4,7 @@ import { MetaData } from '@/ProChat/types/meta';
 import { ChatMessage } from '@/types/message';
 import { AutoCompleteProps } from 'antd';
 import { TextAreaProps } from 'antd/es/input';
+import { type TextAreaRef } from 'antd/es/input/TextArea';
 import { ReactNode } from 'react';
 import { FlexBasicProps } from 'react-layout-kit/lib/FlexBasic';
 import { Locale } from '../../locale';
@@ -85,6 +86,7 @@ export interface ChatPropsState<T extends Record<string, any> = Record<string, a
     autoCompleteProps?: AutoCompleteProps;
     value?: string;
     onChange?: (value: string) => void;
+    reference?: React.Ref<TextAreaRef>;
   };
 
   /**


### PR DESCRIPTION
#### 💻 变更类型 | Change Type
- \[x] ✨ feat
- \[ ] 🐛 fix
- \[ ] 💄 style
- \[ ] 🔨 chore
- \[ ] 📝 docs

#### 🔀 变更说明 | Description of Change

inputAreaProps 中新增reference, 暴露输入框的ref出来
```
/**
 * 输入框的 props,优先级最高
 */
inputAreaProps?: TextAreaProps & {
  autoCompleteProps?: AutoCompleteProps;
  value?: string;
  onChange?: (value: string) => void;
  reference?: React.Ref<TextAreaRef>;
};
```

#### 📝 补充信息 | Additional Information

![chrome-capture-2024-5-29](https://github.com/ant-design/pro-chat/assets/22296845/bdfe294b-4d73-41d7-b28c-1ee7d01c75ca)

