### PR TITLE
🐛 fix: ActionIconGroup不设置dropdownMenu, 依旧显示...省略号

### DIFF
--- a/src/ActionIconGroup/index.tsx
+++ b/src/ActionIconGroup/index.tsx
@@ -61,7 +61,7 @@ const ActionIconGroup = memo<ActionIconGroupProps>(
     placement,
     spotlight = false,
     direction = 'row',
-    dropdownMenu = [],
+    dropdownMenu = null,
     onActionClick,
     className,
     style,


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- \[ ] ✨ feat
- \[x] 🐛 fix
- \[ ] 💄 style
- \[ ] 🔨 chore
- \[ ] 📝 docs

#### 🔀 变更说明 | Description of Change

需求: 不传入dropdownMenu的时候, 则不展示...省略号
可以传入null来解决, 但是会被typescript校验不通过, 因此还是需要调整源码来修复此问题
