### PR TITLE
fix: userMeta设置backgroundColor 不生效的问题

### DIFF
--- a/src/ProChat/store/selectors/chat.ts
+++ b/src/ProChat/store/selectors/chat.ts
@@ -13,11 +13,13 @@ export const currentChats = (s: ChatStore): ChatMessage[] => {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { avatar, title, backgroundColor, ...rest } = s.userMeta;
     const assistant = s.assistantMeta;
+    const user = s.userMeta;
     switch (message?.role) {
       case 'user': {
         return {
           avatar,
           title,
+          backgroundColor: user?.backgroundColor,
           ...rest,
         };
       }


### PR DESCRIPTION
userMeta 设置 backgroundColor 无效, 修改后支持从userMeta 获取 backgroundColor 的值来渲染

#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- \[ ] ✨ feat
- \[x] 🐛 fix
- \[ ] 💄 style
- \[ ] 🔨 chore
- \[ ] 📝 docs

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->
